### PR TITLE
Fix m_direction_vectors cast to const uint ptr

### DIFF
--- a/library/src/rng/sobol32.hpp
+++ b/library/src/rng/sobol32.hpp
@@ -160,7 +160,7 @@ public:
             HIP_KERNEL_NAME(rocrand_host::detail::generate_kernel),
             dim3(blocks_x, blocks_y), dim3(threads), 0, m_stream,
             data, size,
-            m_direction_vectors, m_current_offset,
+            static_cast<const unsigned int*>(m_direction_vectors), m_current_offset,
             distribution
         );
         // Check kernel status


### PR DESCRIPTION
There is a mismatch between this generate_kernel callsite and the function. Cannot take a non-const unsigned int when the function requires a const uint ptr as 3rd argument. generate_kernel = void ( * )(T*, const size_t, **const unsigned int***, const unsigned int, Distribution)