### PR TITLE
Fix generate_func to pass-by-value

### DIFF
--- a/test/crush/stat_test_curand_kernel.cpp
+++ b/test/crush/stat_test_curand_kernel.cpp
@@ -80,7 +80,7 @@ __global__
 void generate_kernel(GeneratorState * states,
                      T * data,
                      const size_t size,
-                     const GenerateFunc& generate_func,
+                     GenerateFunc generate_func,
                      const Extra extra)
 {
     const unsigned int state_id = blockIdx.x * blockDim.x + threadIdx.x;
@@ -138,7 +138,7 @@ __global__
 void generate_kernel(curandStateMtgp32_t * states,
                      T * data,
                      const size_t size,
-                     const GenerateFunc& generate_func,
+                     GenerateFunc generate_func,
                      const Extra extra)
 {
     const unsigned int state_id = blockIdx.x;
@@ -223,7 +223,7 @@ __global__
 void generate_kernel(curandStateSobol32_t * states,
                      T * data,
                      const size_t size,
-                     const GenerateFunc& generate_func,
+                     GenerateFunc generate_func,
                      const Extra extra)
 {
     const unsigned int dimension = blockIdx.y;


### PR DESCRIPTION
Seems that generate_func lambda function is being passed into the kernel function by reference. The signature is wrong and this is out of the spec, so generate_func should be passed by value. This is CUDA compliant.